### PR TITLE
fix: handle duplicate email registration with 409 status

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -75,7 +75,7 @@ app.post('/register', (req, res) => {
                 console.error('Error inserting user:', err);
               
                 if (err.code === 'ER_DUP_ENTRY') { 
-                    return res.status(409).send('User with this email already exists.');
+                    return res.status(409).json({ message: 'User with this email already exists.' });
                 }
                 res.status(500).send('Error registering user');
             } else {


### PR DESCRIPTION
This PR updates the registration route to return a 409 Conflict status with a clear message when a user tries to register with an already existing email. This improves error handling and provides better feedback to the frontend.